### PR TITLE
In `PrettyLinkWithAdditionalInfosColumn`, removed to setup around cur…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ Changelog
 2.10 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- In `PrettyLinkWithAdditionalInfosColumn`, removed to setup around current URL
+  that was necessary for displaying image and files correctly but instead,
+  require `plone.formwidget.namedfile>=2.0.2` that solves the problem.
+  [gbastien]
 
 2.9 (2020-02-25)
 ----------------

--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -6,6 +6,7 @@ Products.Clouseau = 1.0
 Products.DocFinderTab = 1.0.5
 Products.PDBDebugMode = 1.3.1
 Products.PrintingMailHost = 0.7
+plone.formwidget.namedfile = 2.0.5
 eea.facetednavigation =
 PyYAML = 3.10
 argh = 0.24.1

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'collective.excelexport',
         'eea.facetednavigation>10.0',
         'plone.api>=1.3.0',
+        'plone.formwidget.namedfile>=2.0.2',
         'setuptools',
         'z3c.table',
     ],

--- a/src/collective/eeafaceted/z3ctable/columns.py
+++ b/src/collective/eeafaceted/z3ctable/columns.py
@@ -637,9 +637,6 @@ class PrettyLinkWithAdditionalInfosColumn(PrettyLinkColumn):
     def additional_infos(self, item):
         """ """
         res = u''
-        # Need to patch url for links to downloadable files to work...
-        old_url = self.request.getURL()
-
         # caching
         obj = self._getObject(item)
         # display description if relevant
@@ -649,7 +646,6 @@ class PrettyLinkWithAdditionalInfosColumn(PrettyLinkColumn):
                 res = u'<div class="discreet"><label class="horizontal">Description</label>' \
                     '<div>{0}</div></div>'.format(description)
         if not self.use_caching or getattr(self, '_cached_view', None) is None:
-            self.request.set('URL', self.context.absolute_url() + '/view')
             view = obj.restrictedTraverse('view')
             self._cached_view = view
             view.update()
@@ -689,8 +685,6 @@ class PrettyLinkWithAdditionalInfosColumn(PrettyLinkColumn):
                     _rendered_value = widget.render()
                 res += self.ai_widget_render_pattern.format(
                     translated_label, _rendered_value, css_class, field_css_class)
-        # unpatch URL
-        self.request.set('URL', old_url)
         return res
 
     def _render_datagridfield(self, view, widget):


### PR DESCRIPTION
…rent URL that was necessary for displaying image and files correctly but instead, require `plone.formwidget.namedfile>=2.0.2` that solves the problem, see #PM-3180