### PR TITLE
Mpmphai 78 make header slim and sticky

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 - Added possibility to define a `header_help` message that will be displayed
   when hovering header title.
   [gbastien]
+- Added `<label>` tag around input for the `CheckBoxColumn` so it can be syled
+  to ease checkbox selection on click.
+  [gbastien]
 
 2.12 (2020-10-02)
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,9 @@ Changelog
 2.13 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Added possibility to define a `header_help` message that will be displayed
+  when hovering header title.
+  [gbastien]
 
 2.12 (2020-10-02)
 -----------------

--- a/src/collective/eeafaceted/z3ctable/columns.py
+++ b/src/collective/eeafaceted/z3ctable/columns.py
@@ -53,6 +53,8 @@ class BaseColumn(column.GetAttrColumn):
     header_image = None
     # we can inject some javascript in the header
     header_js = None
+    # header help message
+    header_help = u"tralala"
     # enable caching, needs to be implemented by Column
     use_caching = True
 
@@ -107,6 +109,10 @@ class BaseColumnHeader(SortingColumnHeader):
         # inject some javascript in the header?
         if self.column.header_js:
             header = self.column.header_js + header
+        # include help message
+        if self.column.header_help:
+            header = u'<acronym title="{0}">{1}</acronym>'.format(
+                self.column.header_help, header)
         # a column can specifically declare that it is not sortable
         # by setting sort_index to -1
         if not self.column.sort_index == -1:

--- a/src/collective/eeafaceted/z3ctable/columns.py
+++ b/src/collective/eeafaceted/z3ctable/columns.py
@@ -54,7 +54,7 @@ class BaseColumn(column.GetAttrColumn):
     # we can inject some javascript in the header
     header_js = None
     # header help message
-    header_help = u"tralala"
+    header_help = None
     # enable caching, needs to be implemented by Column
     use_caching = True
 
@@ -111,8 +111,12 @@ class BaseColumnHeader(SortingColumnHeader):
             header = self.column.header_js + header
         # include help message
         if self.column.header_help:
+            header_help = translate(
+                self.column.header_help,
+                domain='collective.eeafaceted.z3ctable',
+                context=self.request)
             header = u'<acronym title="{0}">{1}</acronym>'.format(
-                self.column.header_help, header)
+                header_help, header)
         # a column can specifically declare that it is not sortable
         # by setting sort_index to -1
         if not self.column.sort_index == -1:
@@ -499,7 +503,7 @@ class CheckBoxColumn(BaseColumn):
 
     def renderCell(self, item):
         """ """
-        return u'<input type="checkbox" name="%s" value="%s" %s/>' \
+        return u'<label class="select-item-label"><input type="checkbox" name="%s" value="%s" %s/></label>' \
             % (self.name, self.getValue(item), self.checked_by_default and "checked " or "")
 
     def getCSSClasses(self, item):

--- a/src/collective/eeafaceted/z3ctable/tests/test_columns.py
+++ b/src/collective/eeafaceted/z3ctable/tests/test_columns.py
@@ -425,30 +425,38 @@ class TestColumns(IntegrationTestCase):
         brain = self.portal.portal_catalog(UID=self.eea_folder.UID())[0]
         self.assertEqual(column.renderHeadCell(),
                          u'<input type="checkbox" id="select_unselect_items" '
-                         'onClick="toggleCheckboxes(\'select_item\')" '
-                         'title="Select/unselect all" checked />')
+                         u'onClick="toggleCheckboxes(\'select_item\')" '
+                         u'title="Select/unselect all" checked />')
         self.assertEqual(column.renderCell(brain),
-                         u'<input type="checkbox" name="select_item" value="%s" checked />' % brain.UID)
+                         u'<label class="select-item-label">'
+                         u'<input type="checkbox" name="select_item" value="%s" checked />'
+                         u'</label>' % brain.UID)
         # column could be unchecked by default
         column.checked_by_default = False
         self.assertEqual(column.renderHeadCell(),
                          u'<input type="checkbox" id="select_unselect_items" '
-                         'onClick="toggleCheckboxes(\'select_item\')" '
-                         'title="Select/unselect all" />')
+                         u'onClick="toggleCheckboxes(\'select_item\')" '
+                         u'title="Select/unselect all" />')
         self.assertEqual(column.renderCell(brain),
-                         u'<input type="checkbox" name="select_item" value="%s" />' % brain.UID)
+                         u'<label class="select-item-label">'
+                         u'<input type="checkbox" name="select_item" value="%s" />'
+                         u'</label>' % brain.UID)
         # name can be changed
         column.name = u'select_element'
         self.assertEqual(column.renderHeadCell(),
                          u'<input type="checkbox" id="select_unselect_items" '
-                         'onClick="toggleCheckboxes(\'select_element\')" '
-                         'title="Select/unselect all" />')
+                         u'onClick="toggleCheckboxes(\'select_element\')" '
+                         u'title="Select/unselect all" />')
         self.assertEqual(column.renderCell(brain),
-                         u'<input type="checkbox" name="select_element" value="%s" />' % brain.UID)
+                         u'<label class="select-item-label">'
+                         u'<input type="checkbox" name="select_element" value="%s" />'
+                         u'</label>' % brain.UID)
         # attrName can be changed
         column.attrName = 'getId'
         self.assertEqual(column.renderCell(brain),
-                         u'<input type="checkbox" name="select_element" value="eea_folder" />')
+                         u'<label class="select-item-label">'
+                         u'<input type="checkbox" name="select_element" value="eea_folder" />'
+                         u'</label>')
         # a custom CSS class is generated
         self.assertEqual(column.getCSSClasses(brain), {'td': 'select_element_checkbox'})
 

--- a/src/collective/eeafaceted/z3ctable/tests/test_columns.py
+++ b/src/collective/eeafaceted/z3ctable/tests/test_columns.py
@@ -111,6 +111,12 @@ class TestColumns(IntegrationTestCase):
         column.header_image = 'image.png'
         self.assertEqual(column.renderHeadCell(),
                          u'<img src="http://nohost/plone/image.png" title="Title" />')
+        # define a help message
+        column.header_help = u'My help message'
+        self.assertEqual(column.renderHeadCell(),
+                         u'<acronym title="My help message">'
+                         u'<img src="http://nohost/plone/image.png" title="Title" />'
+                         u'</acronym>')
 
     def test_AwakeObjectGetAttrColumn(self):
         """This will wake the given catalog brain and getattr the attrName on it.


### PR DESCRIPTION
Salut @sgeulette 

j'ai ajouté la possibilité de définir un "header_help" sur un header de colonne, ceci permet d'avoir un message d'aide au survol du titre du header, çà nous permet par exemple de diminuer la hauteur du header, avant on avait "Groupes en charge", maintenant au a "G.C." et au survol çà affiche "Groupes en charge".

Par défaut ce n'est pas activé donc çà ne change rien...

J'ai aussi ajouté un label autour de la selectbox pour la colonne "case à cocher", ceci permet en CSS de rendre plus facilement cliquable car cliquer sur le label permet de cocher/décocher, pour l'instant il faut vraiment cliquer sur la case, par après çà permettra même en cliquant "autour" de la case de la sélectionner, un peu plus confortable...

Voilà regarde, et merge si ok, merci ;-)

Gauthier