### PR TITLE
Extended JS function `toggleCheckboxes`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,10 @@ Changelog
 2.19 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Extended JS function `toggleCheckboxes` to pass the select/unselect checkbox
+  as first parameter and trigger the click event when checkboxes checked or unchecked.
+  This changes nothing here but makes this function more useable in other contexts.
+  [gbastien]
 
 2.18 (2022-06-14)
 -----------------

--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -10,3 +10,5 @@ plone.formwidget.namedfile = 2.0.6
 # Required by:
 # collective.fingerpointing
 zc.lockfile = 2.0
+pep517 = 0.8.2
+zope.configuration = 3.8.1

--- a/src/collective/eeafaceted/z3ctable/browser/static/collective.eeafaceted.z3ctable.js
+++ b/src/collective/eeafaceted/z3ctable/browser/static/collective.eeafaceted.z3ctable.js
@@ -1,14 +1,19 @@
 // (un)select every checkboxes
-function toggleCheckboxes(checkBoxId) {
-    checkbox = $('input#select_unselect_items[name="' + checkBoxId + '"]');
-    if (checkbox[0].checked) {
+function toggleCheckboxes(checkbox, checkBoxId) {
+    if (checkbox.checked) {
         $('input[name="' + checkBoxId + '"]').each(function() {
-            this.checked = true;
+            if (this.checked == false) {
+                this.checked = true;
+                this.dispatchEvent(new Event('click'));
+            }
         });
     }
     else {
         $('input[name="' + checkBoxId + '"]').each(function() {
-            this.checked = false;
+            if (this.checked == true) {
+                this.checked = false;
+                this.dispatchEvent(new Event('click'));
+            }
         });
     }
 }

--- a/src/collective/eeafaceted/z3ctable/browser/static/collective.eeafaceted.z3ctable.js
+++ b/src/collective/eeafaceted/z3ctable/browser/static/collective.eeafaceted.z3ctable.js
@@ -1,7 +1,7 @@
 // (un)select every checkboxes
-function toggleCheckboxes(checkbox, checkBoxId) {
+function toggleCheckboxes(checkbox, checkBoxId, attrName="name", selector="=") {
     if (checkbox.checked) {
-        $('input[name="' + checkBoxId + '"]').each(function() {
+        $('input[' + attrName + selector + '"' + checkBoxId + '"]').each(function() {
             if (this.checked == false) {
                 this.checked = true;
                 this.dispatchEvent(new Event('click'));
@@ -9,7 +9,7 @@ function toggleCheckboxes(checkbox, checkBoxId) {
         });
     }
     else {
-        $('input[name="' + checkBoxId + '"]').each(function() {
+        $('input[' + attrName + selector + '"' + checkBoxId + '"]').each(function() {
             if (this.checked == true) {
                 this.checked = false;
                 this.dispatchEvent(new Event('click'));

--- a/src/collective/eeafaceted/z3ctable/columns.py
+++ b/src/collective/eeafaceted/z3ctable/columns.py
@@ -511,7 +511,7 @@ class CheckBoxColumn(BaseColumn):
                           domain='collective.eeafaceted.z3ctable',
                           context=self.request,
                           default="Select/unselect all")
-        return u'<input type="checkbox" id="select_unselect_items" onClick="toggleCheckboxes(\'{0}\')" ' \
+        return u'<input type="checkbox" id="select_unselect_items" onClick="toggleCheckboxes(this, \'{0}\')" ' \
                u'title="{1}" name="{0}" {2}/>'.format(
                    self.name, title, self.checked_by_default and "checked " or "")
 

--- a/src/collective/eeafaceted/z3ctable/tests/test_columns.py
+++ b/src/collective/eeafaceted/z3ctable/tests/test_columns.py
@@ -427,7 +427,7 @@ class TestColumns(IntegrationTestCase):
         brain = self.portal.portal_catalog(UID=self.eea_folder.UID())[0]
         self.assertEqual(column.renderHeadCell(),
                          u'<input type="checkbox" id="select_unselect_items" '
-                         u'onClick="toggleCheckboxes(\'select_item\')" '
+                         u'onClick="toggleCheckboxes(this, \'select_item\')" '
                          u'title="Select/unselect all" name="select_item" checked />')
         self.assertEqual(column.renderCell(brain),
                          u'<label class="select-item-label">'

--- a/src/collective/eeafaceted/z3ctable/tests/test_columns.py
+++ b/src/collective/eeafaceted/z3ctable/tests/test_columns.py
@@ -437,7 +437,7 @@ class TestColumns(IntegrationTestCase):
         column.checked_by_default = False
         self.assertEqual(column.renderHeadCell(),
                          u'<input type="checkbox" id="select_unselect_items" '
-                         u'onClick="toggleCheckboxes(\'select_item\')" '
+                         u'onClick="toggleCheckboxes(this, \'select_item\')" '
                          u'title="Select/unselect all" name="select_item" />')
         self.assertEqual(column.renderCell(brain),
                          u'<label class="select-item-label">'
@@ -447,7 +447,7 @@ class TestColumns(IntegrationTestCase):
         column.name = u'select_element'
         self.assertEqual(column.renderHeadCell(),
                          u'<input type="checkbox" id="select_unselect_items" '
-                         u'onClick="toggleCheckboxes(\'select_element\')" '
+                         u'onClick="toggleCheckboxes(this, \'select_element\')" '
                          u'title="Select/unselect all" name="select_element" />')
         self.assertEqual(column.renderCell(brain),
                          u'<label class="select-item-label">'


### PR DESCRIPTION
 to pass the select/unselect checkbox as first parameter and trigger the click event when checkboxes checked or unchecked. This changes nothing here but makes this function more useable in other contexts.

See #PM-3984