### PR TITLE
JS function `preventDefaultClickTransition` was renamed to `preventDefaultClick` in `imio.actionspanel>=1.62`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Changelog
   as first parameter and trigger the click event when checkboxes checked or unchecked.
   This changes nothing here but makes this function more useable in other contexts.
   [gbastien]
+- JS function `preventDefaultClickTransition` was renamed to
+  `preventDefaultClickTransition` in `imio.actionspanel>=1.62`.
+  [gbastien]
 
 2.18 (2022-06-14)
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Changelog
   This changes nothing here but makes this function more useable in other contexts.
   [gbastien]
 - JS function `preventDefaultClickTransition` was renamed to
-  `preventDefaultClickTransition` in `imio.actionspanel>=1.62`.
+  `preventDefaultClick` in `imio.actionspanel>=1.62`.
   [gbastien]
 
 2.18 (2022-06-14)

--- a/src/collective/eeafaceted/z3ctable/columns.py
+++ b/src/collective/eeafaceted/z3ctable/columns.py
@@ -782,7 +782,7 @@ class ActionsColumn(BrowserViewCallColumn):
     """
 
     header_js = '<script type="text/javascript">jQuery(document).ready(initializeOverlays);' \
-                'jQuery(document).ready(preventDefaultClickTransition);</script>'
+                'jQuery(document).ready(preventDefaultClick);</script>'
     view_name = 'actions_panel'
     params = {'showHistory': True, 'showActions': True}
     # not necessary to escape, everything is generated


### PR DESCRIPTION
See #PM-3955